### PR TITLE
Release/2.0.5

### DIFF
--- a/internal/domain/constants.go
+++ b/internal/domain/constants.go
@@ -1,7 +1,7 @@
 package domain
 
 const (
-	Version                       = "2.0.4.RC"
+	Version                       = "2.0.5"
 	AppDataFolder                 = ".app-data"
 	ConfigsFolder                 = ".configs"
 	OutboundFolder                = ".outbound"

--- a/internal/domain/models.go
+++ b/internal/domain/models.go
@@ -14,10 +14,11 @@ type Config struct {
 }
 
 type OutboundConfig struct {
-	OutboundFolder   string `json:"outboundFolder"`
-	Buffered         bool   `json:"buffered"`
-	JustSendBuffered bool   `json:"justSendBuffered"`
-	IgnoreStatus     bool   `json:"ignoreStatus"`
+	OutboundFolder   string  `json:"outboundFolder"`
+	PartitionKey     *string `json:"partitionKey"`
+	Buffered         bool    `json:"buffered"`
+	JustSendBuffered bool    `json:"justSendBuffered"`
+	IgnoreStatus     bool    `json:"ignoreStatus"`
 }
 
 type InboundConfig struct {

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,8 @@ Note that all paths that have default values are relative to the application loc
     "outboundFolder": ".outbound",
     "buffered": false,
     "justSendBuffered": false,
-    "ignoreStatus": false
+    "ignoreStatus": false,    
+    "partitionKey": null
   }
 }
 ```
@@ -196,6 +197,18 @@ Note that all paths that have default values are relative to the application loc
 ```
 
 
+#### Sending each message only 1x, with a custom PartitionKey.
+```json
+{
+  "EventHubConnString": "<REQUIRED! NO DEFAULT!>",
+  "entityPath": "<REQUIRED! NO DEFAULT!>",
+  "outboundConfig": {
+    "outboundFolder": "c:\\messages_to_send",
+    "partitionKey": "my-partition-key"
+  }  
+} 
+```
+
 ## Understanding the config file.
 ### Root section
 1. **EventHubConnString**: This is required for **Hub Read** and **Hub Send**. It's the connection string that will be used to connect to EventHub
@@ -221,6 +234,7 @@ Note that all paths that have default values are relative to the application loc
 2. **buffered**: Optional with default of ```false```. If true, will buffer (save to database) all messages first and then send them.
 3. **justSendBuffered**: Optional with default of ```false```. If true, will skip buffering and just send the messages that were already saved to the buffer.
 4. **ignoreStatus**: Optional with default of ```false```. If true, will send every message again. By default, once a message is sent, **Hub Send** will not try to send it again.
+5. **partitionKey**: Optional with default of ```null```. If set, this information will be added to every message sent. Attention: If set, all messages will be sent using the same PartitionKey. 
 
 
 # Attention Mac users!


### PR DESCRIPTION
Added option to set a partition key to the outgoing messages.
To use it, add the "partitionKey" property to the "outboundConfig" section. 

Example from readme.md:
#### Sending each message only 1x, with a custom PartitionKey.
```json
{
  "EventHubConnString": "<REQUIRED! NO DEFAULT!>",
  "entityPath": "<REQUIRED! NO DEFAULT!>",
  "outboundConfig": {
    "outboundFolder": "c:\\messages_to_send",
    "partitionKey": "my-partition-key"
  }  
} 
```